### PR TITLE
Fix so it connects to device using the newest version of serialport

### DIFF
--- a/gsm.js
+++ b/gsm.js
@@ -19,9 +19,9 @@ var GSM = function(port, baud) {
     
     this._clear();
     
-    var SerialPort = sp.SerialPort;
-    this._sp = new SerialPort(port, {
-        baudrate: baud
+    this._sp = new sp(port, {
+        baudrate: baud,
+        autoOpen:false
     }); 
 };
 


### PR DESCRIPTION
only tested on raspberry pi 3 using A6 GSM connected to UART. But should fix all connection issues as its related to changes in serialport module.